### PR TITLE
Add checks to strComputerName and  strFullComputerName size

### DIFF
--- a/src/OrcCommand/WolfLauncher_Config.cpp
+++ b/src/OrcCommand/WolfLauncher_Config.cpp
@@ -562,12 +562,32 @@ HRESULT Main::GetConfigurationFromArgcArgv(int argc, LPCWSTR argv[])
 
         if (strComputerName.empty() && !strFullComputerName.empty())
         {
-            strComputerName = strFullComputerName;
+            size_t pos = strFullComputerName.find(L".");
+
+            if (pos != std::string::npos)
+            {
+                strComputerName = strFullComputerName.substr(0, pos);
+            }
+            else
+            {
+                strComputerName = strFullComputerName;
+            }
         }
         if (strFullComputerName.empty() && !strComputerName.empty())
         {
             strFullComputerName = strComputerName;
         }
+
+        if (strComputerName.length() > MAX_COMPUTERNAME_LENGTH)
+        {
+            log::Error(
+                _L_,
+                E_FAIL,
+                L"ComputerName (defined by /Compter or /CompterFull) must be shorter or equal to %d characters\r\n", MAX_COMPUTERNAME_LENGTH);
+
+            return E_FAIL;
+        } 
+
         if (!strComputerName.empty())
             SystemDetails::SetOrcComputerName(strComputerName);
         if (!strFullComputerName.empty())


### PR DESCRIPTION
Hello,

There was not size check on `strComputerName ` and not ComputerName extraction from `strComputerNameFull`.
A ComputerName longer than `MAX_COMPUTER_NAME_LENGTH` characters cause an overflow and error in the csv Column CompterName.

Due to `szComputerName `and `szOrcComputerName` size is `MAX_COMPUTER_NAME_LENGTH` and `strComputerName ` or `strComputerNameFull` copied without check.

Regards,