### PR TITLE
Fixing config check in RegInfo tool

### DIFF
--- a/src/OrcLib/OutputSpecTypes.h
+++ b/src/OrcLib/OutputSpecTypes.h
@@ -55,19 +55,19 @@ enum class UploadMode : char
 
 enum class Kind
 {
-    None = 0,
-    TableFile = 1 << 0,
-    StructuredFile = 1 << 1,
-    File = 1 << 2,
-    Archive = 1 << 3,
-    Directory = 1 << 4,
-    Pipe = 1 << 5,
-    CSV = 1 << 6,
-    TSV = 1 << 7,
-    Parquet = 1 << 8,
-    XML = 1 << 9,
-    JSON = 1 << 10,
-    ORC = 1 << 11
+    None = 1,
+    TableFile = 1 << 1,
+    StructuredFile = 1 << 2,
+    File = 1 << 3,
+    Archive = 1 << 4,
+    Directory = 1 << 5,
+    Pipe = 1 << 6,
+    CSV = 1 << 7,
+    TSV = 1 << 8,
+    Parquet = 1 << 9,
+    XML = 1 << 10,
+    JSON = 1 << 11,
+    ORC = 1 << 12
 };
 
 enum Disposition


### PR DESCRIPTION
Hello, 

Following the official documentation on the usage of `RegInfo`, we need to provide an XML configuration file which allows us to provide an output directory or file (csv, tsv). But we obtain the following message : `No valid output specified (only directory or csv|tsv are allowed` using the documentation configuration file and command line.

The function `CheckConfiguration` in `RegInfo_Config.cpp` checks if the output type is `None`. These output types are defined in `OutputSpec::Kind`, and the `None` output is equal to `0`. However, the `CheckConfiguration` uses the `HasFlag` and when checking if the output is `None` (0), the return value will always be true because of the `(value & flag) == flag` computation.

On my side, I've changed the `OutputSpecTypes` by starting the `None` output value to 1, and incrementing the shift value of the other outputs which seams to solve this issue.

Pierre