### PR TITLE
Typo in GetThis error message MaxBytesTotal vs MaxTotalBytes

### DIFF
--- a/src/OrcCommand/Command/GetThis/GetThis_Config.cpp
+++ b/src/OrcCommand/Command/GetThis/GetThis_Config.cpp
@@ -462,7 +462,7 @@ HRESULT Main::CheckConfiguration()
         && (config.limits.dwlMaxBytesTotal == INFINITE && config.limits.dwMaxSampleCount == INFINITE))
     {
         Log::Critical(
-            L"No global (at samples level, MaxBytesTotal or MaxSampleCount) has been set: set limits in configuration "
+            L"No global (at samples level, MaxTotalBytes or MaxSampleCount) has been set: set limits in configuration "
             L"or use /nolimits");
         return E_INVALIDARG;
     }


### PR DESCRIPTION
Fix a typo in error message between  MaxBytesTotal and MaxTotalBytes