### PR TITLE
Add ANSSI metadata to the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to This Project
+
+Thank you for your interest in this project. Please read this document
+carefully before considering any contributions.
+
+## Scope of Contributions
+
+This project will review all kind of contributions but not all of them will be reviewed or accepted. Review will depend on the maintainers time and the relevance of the contribution. Security-oriented contribution will be processed fastly (more details about security below).
+
+## Support Policy
+
+Thank you for understanding and respecting the limited scope of this project's
+contributions and support. In particular, there is no commitment regarding
+processing times.
+
+### Limited Support Scope
+
+- Support is provided exclusively to contributors improvements.
+- The project maintainers will only assist with issues directly related to your
+  contributions.
+
+### No General Support
+
+- We do not offer general support for using or setting up the project.
+- ANSSI beneficiaries should reach out their usual point of contact for support.
+
+Questions, feature requests, or issues unrelated to active contributions will
+not be addressed.
+
+## How to Contribute
+
+1. Open an issue describing the kind of improvements you want to contribute and
+   wait for team feedback.
+2. Fork the repository and create a new branch for your work.
+3. Submit a pull request with a clear description of your improvements.
+
+## Security Vulnerabilities
+
+If you discover a security vulnerability, please report it according to our
+security policy outlined in the [`SECURITY.md`](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # DFIR ORC
 [![LGPL licensed][img-license]](./LICENSE.txt)
+[![badge_repo](https://img.shields.io/badge/DFIR--ORC-DFIR--ORC-white)](https://github.com/DFIR-ORC/dfir-orc)
+[![category_badge_external](https://img.shields.io/badge/category-external-%23b556b6)](https://anssi-fr.github.io/README.en.html#project-categories)
+[![openess_badge_A](https://img.shields.io/badge/code.gouv.fr-collaborative-blue)](https://documentation.ouvert.numerique.gouv.fr/les-parcours-de-documentation/ouvrir-un-projet-num%C3%A9rique/#niveau-ouverture)
 
+<img src="https://dfir-orc.github.io/_static/logo.jpg" alt="DFIR-ORC" height="128"><img src="https://www.sgdsn.gouv.fr/files/styles/ds_image_paragraphe/public/files/Notre_Organisation/logo_anssi.png" alt="ANSSI logo" height="128">
 
+## French Cybersecurity Agency (ANSSI)
+
+*This projet is managed by [ANSSI](https://cyber.gouv.fr/). To find out more, you can visit the [page](https://cyber.gouv.fr/enjeux-technologiques/open-source/) (in French) dedicated to ANSSI’s open-source strategy. You can also click on the badges above to learn more about their meaning.*
 ## Documentation
 https://dfir-orc.github.io
 
@@ -77,12 +84,12 @@ cmake --build . --config MinSizeRel -- -maxcpucount
 ## License
 
 The contents of this repository is available under [LGPL2.1+ license](LICENSE.txt).
-The name DFIR ORC and the associated logo belongs to ANSSI, no use is permitted without express approval.
+The name DFIR ORC, the associated logo and the ANSSI logo belong to ANSSI, no use is permitted without express approval.
 
 ---
 
 Le contenu de ce dépôt est disponible sous licence LGPL2.1+, tel qu'indiqué [ici](LICENSE.txt).
-Le nom DFIR ORC et le logo associé appartiennent à l'ANSSI, aucun usage n'est permis sans autorisation expresse.
+Le nom DFIR ORC, le logo associé et le logo de l'ANSSI appartiennent à l'ANSSI, aucun usage n'est permis sans autorisation expresse.
 
 
 ## Acknowledgments

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please help us
+address it responsibly by following these steps:
+
+1. **Do not publicly disclose the vulnerability.**
+2. Contact us directly at
+   [dfir-orc@ssi.gouv.fr](mailto:dfir-orc@ssi.gouv.fr) with the following
+   details:
+   - A clear description of the issue.
+   - Steps to reproduce the vulnerability.
+   - Any potential impact or exploit scenarios.
+
+Thank you for helping us keep this project secure!


### PR DESCRIPTION
Hey team

here's a PR to add some ANSSI metadata to the repository, following the publication of the ANSSI [open source strategy](https://cyber.gouv.fr/enjeux-technologiques/open-source/).

The [project category](https://anssi-fr.github.io/README.en.html#project-categories) and the [openness level](https://anssi-fr.github.io/README.en.html#openness-level) can be adjusted, as well as the content of the SECURITY and CONTRIBUTING files, if you think other choices make more sense.

I've set the "openness level" to A ("contributive") and wrote the CONTRIBUTING.md accordingly because it seems that PR are indeed welcome and handled, but feel free to adjust the wording as you see fit (same for the "general support").

I've pointed the security policy to the dfir-orc email address but again you're free to adjust that (some ANSSI projects use Github security advisories as well).

Thank you for your consideration.